### PR TITLE
End-to-end encryption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1470,6 +1470,10 @@
       "integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg==",
       "dev": true
     },
+    "aes128gcm-stream": {
+      "version": "git+https://github.com/nwtgck/aes128gcm-stream-npm.git#010001edb3fc0978510c0f46f71232e0956730a5",
+      "from": "git+https://github.com/nwtgck/aes128gcm-stream-npm.git#v0.1.1"
+    },
     "ajv": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "aes128gcm-stream": "git+https://github.com/nwtgck/aes128gcm-stream-npm.git#v0.1.1",
     "core-js": "^2.6.5",
     "filepond": "^4.4.0",
     "register-service-worker": "^1.6.2",

--- a/src/components/GetFile.vue
+++ b/src/components/GetFile.vue
@@ -13,7 +13,9 @@
       label="Passphrase (optional)"
       v-model="passphrase"
       placeholder="Input passphrase"
-      type="password"
+      :type="showPassphrase ? 'text' : 'password'"
+      :append-icon="showPassphrase ? 'visibility' : 'visibility_off'"
+      @click:append="showPassphrase = !showPassphrase"
     />
     <v-text-field
       label="Simultaneous requests"
@@ -43,6 +45,7 @@ import * as aes128gcmStream from 'aes128gcm-stream';
 export default class GetFile extends Vue {
   private dataId: string = '';
   private passphrase: string = '';
+  private showPassphrase: boolean = false;
   // TODO: Hard code
   private serverUrl: string = 'https://ppng.ml';
   private nSimultaneousReqs: number = 2;

--- a/src/components/GetFile.vue
+++ b/src/components/GetFile.vue
@@ -10,6 +10,12 @@
       placeholder="e.g. mydata"
     />
     <v-text-field
+      label="Passphrase (optional)"
+      v-model="passphrase"
+      placeholder="Input passphrase"
+      type="password"
+    />
+    <v-text-field
       label="Simultaneous requests"
       v-model="nSimultaneousReqs"
       type="number"
@@ -30,10 +36,13 @@
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import { createWriteStream } from 'streamsaver';
 import * as pipingChunk from '@/piping-chunk';
+import * as utils from '@/utils';
+import * as aes128gcmStream from 'aes128gcm-stream';
 
 @Component
 export default class GetFile extends Vue {
   private dataId: string = '';
+  private passphrase: string = '';
   // TODO: Hard code
   private serverUrl: string = 'https://ppng.ml';
   private nSimultaneousReqs: number = 2;
@@ -46,7 +55,7 @@ export default class GetFile extends Vue {
   // Whether get-button is available
   private enableGetButton: boolean = true;
 
-  private get(): void {
+  private async get(): Promise<void> {
     // Disable the button
     this.enableGetButton = false;
 
@@ -61,9 +70,17 @@ export default class GetFile extends Vue {
       this.serverUrl,
       this.dataId,
     );
+    // Generate key from passphrase by SHA-2156
+    const key = await utils.passphraseToKey(this.passphrase);
+    // Decrypt
+    const encryptStream = aes128gcmStream.decryptStream(
+      readableStream,
+      key,
+    );
+
     const filename = 'download';
     // Save as file streamingly
-    const downloadPromise: Promise<void> = readableStream.pipeTo(createWriteStream(filename));
+    const downloadPromise: Promise<void> = encryptStream.pipeTo(createWriteStream(filename));
 
     downloadPromise.finally(() => {
       // Disable indeterminate because finished

--- a/src/components/SendFile.vue
+++ b/src/components/SendFile.vue
@@ -19,7 +19,9 @@
       label="Passphrase (optional)"
       v-model="passphrase"
       placeholder="Input passphrase"
-      type="password"
+      :type="showPassphrase ? 'text' : 'password'"
+      :append-icon="showPassphrase ? 'visibility' : 'visibility_off'"
+      @click:append="showPassphrase = !showPassphrase"
     />
     <v-text-field
       label="Simultaneous requests"
@@ -63,6 +65,7 @@ const FilePond = vueFilePond();
 export default class SendFile extends Vue {
   private dataId: string = '';
   private passphrase: string = '';
+  private showPassphrase: boolean = false;
   // TODO: Hard code
   private serverUrl: string = 'https://ppng.ml';
   private nSimultaneousReqs: number = 2;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,3 +45,11 @@ export function getPregressReadableStream(
 
   return readableStream.pipeThrough(transformStream);
 }
+
+export async function passphraseToKey(passphrase: string): Promise<Uint8Array> {
+  // Convert passphrase string to Uint8Array
+  const passphraseU8Array: Uint8Array = new TextEncoder().encode(passphrase);
+  // Generate key from passphrase by SHA-2156
+  const key = new Uint8Array(await crypto.subtle.digest('SHA-256', passphraseU8Array));
+  return key;
+}


### PR DESCRIPTION
## Added
* Add a feature of end-to-end encryption

The input file is encrypted streamingly by [aes128gcm-stream](https://github.com/nwtgck/aes128gcm-stream-npm). That is originally used in Firefox send. Thank you very much for Firefox Send contributors.

