### PR TITLE
Allow users to download when the browser does not support Streams API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1556,7 +1556,7 @@
     },
     "aes128gcm-stream": {
       "version": "git+https://github.com/nwtgck/aes128gcm-stream-npm.git#572ffb59020d07b7c2b06c05d88be25407295115",
-      "from": "git+https://github.com/nwtgck/aes128gcm-stream-npm.git#572ffb59020d07b7c2b06c05d88be25407295115"
+      "from": "git+https://github.com/nwtgck/aes128gcm-stream-npm.git#v0.1.3"
     },
     "ajv": {
       "version": "6.10.0",
@@ -10211,6 +10211,11 @@
       "requires": {
         "defaults": "^1.0.3"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-2.0.3.tgz",
+      "integrity": "sha512-pOqiHmL3RBAGS+SgOR42RbPU6nc8/n15N2rsOXFYHLnTfs2Z8QHs8AizOeOaYEnhwPN4+hu3M2D9XvAqzvt6MA=="
     },
     "webpack": {
       "version": "4.28.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "vue-class-component": "^7.0.2",
     "vue-filepond": "^5.1.0",
     "vue-property-decorator": "^8.1.0",
-    "vuetify": "^1.5.14"
+    "vuetify": "^1.5.14",
+    "web-streams-polyfill": "^2.0.3"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.7.0",

--- a/src/components/PipingChunk.vue
+++ b/src/components/PipingChunk.vue
@@ -241,49 +241,41 @@ export default class PipingChunk extends Vue {
 
     // Use data ID as file name
     const filename = this.dataId;
-    // Promise notifying download finish
-    const downloadPromise: Promise<void> = (async () => {
-      // If stream-download is supported
-      if (streamSaver.supported) {
-        // Save as file streamingly
-        return downloadStream.pipeTo(
-          streamSaver.createWriteStream(filename),
-        );
-      } else {
-        // Read up chunks and generate blob
-        const chunks: Uint8Array[] = [];
-        const reader = downloadStream.getReader();
-        while (true) {
-          const {done, value} = await reader.read();
-          if (done) {
-            break;
-          }
-          chunks.push(value);
+
+    // If stream-download is supported
+    if (streamSaver.supported) {
+      // Save as file streamingly
+      await downloadStream.pipeTo(
+        streamSaver.createWriteStream(filename),
+      );
+    } else {
+      // Read up chunks and generate blob
+      const chunks: Uint8Array[] = [];
+      const reader = downloadStream.getReader();
+      while (true) {
+        const {done, value} = await reader.read();
+        if (done) {
+          break;
         }
-        const blob = new Blob(chunks);
-        // Generate Blob URL and download
-        const blobUrl = URL.createObjectURL(blob);
-        const aTag = document.createElement('a');
-        aTag.href = blobUrl;
-        aTag.download = filename;
-        document.body.appendChild(aTag);
-        aTag.click();
-        URL.revokeObjectURL(blobUrl);
+        chunks.push(value);
       }
-    })();
+      const blob = new Blob(chunks);
+      // Generate Blob URL and download
+      const blobUrl = URL.createObjectURL(blob);
+      const aTag = document.createElement('a');
+      aTag.href = blobUrl;
+      aTag.download = filename;
+      document.body.appendChild(aTag);
+      aTag.click();
+      URL.revokeObjectURL(blobUrl);
+    }
 
-    // Wait download not to block popup-download
-    await downloadPromise;
-
-    // Do after download
-    downloadPromise.finally(() => {
-      // Disable indeterminate because finished
-      this.progressSetting.indeterminate = false;
-      // Set percentage as 100%
-      this.progressSetting.percentage    = 100;
-      // Enable the button again
-      this.enableActionButton = true;
-    });
+    // Disable indeterminate because finished
+    this.progressSetting.indeterminate = false;
+    // Set percentage as 100%
+    this.progressSetting.percentage    = 100;
+    // Enable the button again
+    this.enableActionButton = true;
   }
 }
 

--- a/src/components/PipingChunk.vue
+++ b/src/components/PipingChunk.vue
@@ -275,7 +275,7 @@ export default class PipingChunk extends Vue {
       aTag.download = filename;
       document.body.appendChild(aTag);
       aTag.click();
-      URL.revokeObjectURL(blobUrl);
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 2000);
     }
 
     // Disable indeterminate because finished

--- a/src/components/PipingChunk.vue
+++ b/src/components/PipingChunk.vue
@@ -52,6 +52,12 @@
           Send
           <v-icon right dark>file_upload</v-icon>
         </v-btn>
+        <v-alert :value="sendOrGet === 'get' && !streamDownloadSupported"
+                 type="warning"
+        >
+          This browser does NOT support stream-download.<br>
+          Whole file data will be temporary on the memory.
+        </v-alert>
         <v-btn v-if="sendOrGet === 'get'"
                color="secondary"
                v-on:click="get()"
@@ -76,7 +82,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
-import * as streamSaver from 'streamsaver';
+import * as streamSaver from 'streamsaver'; // NOTE: load before streams polyfill to detect support
 import * as pipingChunk from '@/piping-chunk';
 import * as utils from '@/utils';
 import * as aes128gcmStream from 'aes128gcm-stream';
@@ -127,6 +133,8 @@ export default class PipingChunk extends Vue {
   private showsSnackbar: boolean = false;
   // Message of snackbar
   private snackbarMessage: string = '';
+  // Whether stream-download is supported
+  private readonly streamDownloadSupported = streamSaver.supported;
 
   // Show error message
   private showSnackbar(message: string): void {


### PR DESCRIPTION
## Added
* Allow users to download when the browser does not support Streams API
* Add web-streams-polyfill

## Background
For example, Safari does not support a part of Streams API such as `TransformStream` and `WritableStream`. In addition, Safari does not allow users to download from `ReadableStream` even if using [StreamSaver.js](https://github.com/jimmywarting/StreamSaver.js?utm_source=recordnotfound.com).

## Non-stream download warning
Users might not download a large file. So it shows a warning.
![image](https://user-images.githubusercontent.com/10933561/57076394-89396100-6d24-11e9-98f0-1070329f1dc9.png)

## NOTE: Stream-upload is available

In Safari, **users can upload streamingly**.  Only downloading is not streamed in some browsers.
