### PR TITLE
Fix saving in iOS Safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -903,6 +903,12 @@
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
     },
+    "@types/file-saver": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.0.tgz",
+      "integrity": "sha512-dxdRrUov2HVTbSRFX+7xwUPlbGYVEZK6PrSqClg2QPos3PNe0bCajkDDkDeeC1znjSH03KOEqVbXpnJuWa2wgQ==",
+      "dev": true
+    },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
@@ -4317,6 +4323,11 @@
           }
         }
       }
+    },
+    "file-saver": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.1.tgz",
+      "integrity": "sha512-dCB3K7/BvAcUmtmh1DzFdv0eXSVJ9IAFt1mw3XZfAexodNRoE29l3xB2EX4wH2q8m/UTzwzEPq/ArYk98kUkBQ=="
     },
     "filepond": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "aes128gcm-stream": "git+https://github.com/nwtgck/aes128gcm-stream-npm.git#v0.1.3",
     "core-js": "^2.6.5",
+    "file-saver": "^2.0.1",
     "filepond": "^4.4.2",
     "promise-limiter": "git+https://github.com/nwtgck/promise-limiter-npm.git#v0.1.0",
     "register-service-worker": "^1.6.2",
@@ -22,6 +23,7 @@
     "web-streams-polyfill": "^2.0.3"
   },
   "devDependencies": {
+    "@types/file-saver": "^2.0.0",
     "@vue/cli-plugin-babel": "^3.7.0",
     "@vue/cli-plugin-pwa": "^3.7.0",
     "@vue/cli-plugin-typescript": "^3.7.0",

--- a/src/components/PipingChunk.vue
+++ b/src/components/PipingChunk.vue
@@ -83,6 +83,7 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import * as streamSaver from 'streamsaver'; // NOTE: load before streams polyfill to detect support
+import * as fileSaver from 'file-saver';
 import * as pipingChunk from '@/piping-chunk';
 import * as utils from '@/utils';
 import * as aes128gcmStream from 'aes128gcm-stream';
@@ -267,15 +268,10 @@ export default class PipingChunk extends Vue {
         }
         chunks.push(value);
       }
+      // Create a blob from chunks
       const blob = new Blob(chunks);
-      // Generate Blob URL and download
-      const blobUrl = URL.createObjectURL(blob);
-      const aTag = document.createElement('a');
-      aTag.href = blobUrl;
-      aTag.download = filename;
-      document.body.appendChild(aTag);
-      aTag.click();
-      setTimeout(() => URL.revokeObjectURL(blobUrl), 2000);
+      // Save
+      fileSaver.saveAs(blob, filename);
     }
 
     // Disable indeterminate because finished


### PR DESCRIPTION
## Fixed
* Fix saving in iOS Safari

Before this PR, in iOS Safari, there is no download and no download-popup. This PR uses [FileSaver.js](https://github.com/eligrey/FileSaver.js/) to allow users to download as a file. 

## Demo

By this PR, you can have like the following page.

![IMG_0006](https://user-images.githubusercontent.com/10933561/57114433-25468500-6d84-11e9-8b31-2cc73f802ec0.PNG)

Users can save into local device by clicking "More..." and "Save to Files."
![IMG_0007](https://user-images.githubusercontent.com/10933561/57114476-5b840480-6d84-11e9-8b44-1c0f9306d348.PNG)

Of course, downloading automatically is more proper. This may be a limitation of saving `Blob` in iOS Safari.

